### PR TITLE
fixed the image upload

### DIFF
--- a/s3Communicator.class.php
+++ b/s3Communicator.class.php
@@ -48,7 +48,14 @@ class S3Communicator {
       $milliseconds = round(microtime(true) * 1000);
       $myFileName = (!$newFileName) ? $milliseconds . ".jpg" : $newFileName;
       try {
-        $upload = $this->s3->upload($this->s3Bucket, $myFileName, fopen($formTmpName, 'rb'));
+        $upload = $this->s3->putObject(
+          [
+            'Bucket' => $this->s3Bucket,
+            'Key' => $myFileName,
+            'SourceFile' => $formTmpName,
+            'ContentType' => 'image/jpg'
+          ]
+        );
       } catch (Exception $e) {
         echo 'Caught exception: ',  $e->getMessage(), "\n";
       }


### PR DESCRIPTION
by using a different S3 upload method, and also had to specify the content type, otherwise it was assuming application/octet-stream.

previous to this, trying to visit the uploaded image from cloudfront would force an image download, rather than displaying the image, when visiting the cloudfront URL.